### PR TITLE
1.17への対応とアップデート

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -31,5 +31,10 @@
       <option name="name" value="BintrayJCenter" />
       <option name="url" value="https://jcenter.bintray.com/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="m2-dv8tion" />
+      <option name="name" value="m2-dv8tion" />
+      <option name="url" value="https://m2.dv8tion.net/releases" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,7 +12,7 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,7 +12,7 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         kotlinVersion = '1.4.20'
         kotlinLanguageVersion = '1.4'
         kotlinApiVersion = '1.4'
-        spigotVersion = '1.16.4-R0.1-SNAPSHOT'
+        spigotVersion = '1.17.1-R0.1-SNAPSHOT'
 
         javaVersion = JavaVersion.VERSION_1_8
     }
@@ -25,7 +25,7 @@ plugins {
 apply plugin: 'kotlin'
 
 group = 'jp.aoichaan0513'
-version = '1.1.4'
+version = '1.1.5'
 
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion
@@ -36,6 +36,10 @@ repositories {
 
     maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
     maven { url 'https://oss.sonatype.org/content/groups/public/' }
+    maven {
+        name 'm2-dv8tion'
+        url 'https://m2.dv8tion.net/releases'
+    }
 }
 
 dependencies {
@@ -46,10 +50,10 @@ dependencies {
 
     // Minecraft
     implementation group: 'org.spigotmc', name: 'spigot-api', version: spigotVersion
-    implementation group: 'net.luckperms', name: 'api', version: '5.2'
+    implementation group: 'net.luckperms', name: 'api', version: '5.3'
 
     // Bot
-    implementation group: 'net.dv8tion', name: 'JDA', version: '4.2.0_222'
+    implementation group: 'net.dv8tion', name: 'JDA', version: '4.3.0_346'
 
     // ツールライブラリ
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'

--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ dependencies {
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-script-util'
 
     // Minecraft
-    implementation group: 'org.spigotmc', name: 'spigot-api', version: spigotVersion
-    implementation group: 'net.luckperms', name: 'api', version: '5.3'
+    compileOnly group: 'org.spigotmc', name: 'spigot-api', version: spigotVersion
+    compileOnly group: 'net.luckperms', name: 'api', version: '5.3'
 
     // Bot
     implementation group: 'net.dv8tion', name: 'JDA', version: '4.3.0_346'

--- a/src/main/kotlin/jp/aoichaan0513/fslink/Main.kt
+++ b/src/main/kotlin/jp/aoichaan0513/fslink/Main.kt
@@ -31,8 +31,11 @@ class Main : JavaPlugin() {
         saveDefaultConfig()
 
         val provider = Bukkit.getServicesManager().getRegistration(LuckPerms::class.java)
-        if (provider != null)
-            luckPerms = LuckPermsProvider.get()
+        if (provider != null) {
+            luckPerms = provider.provider
+        } else {
+            throw RuntimeException("LuckPerms not found!")
+        }
 
         loadCommands()
         loadListeners()

--- a/src/main/kotlin/jp/aoichaan0513/fslink/Main.kt
+++ b/src/main/kotlin/jp/aoichaan0513/fslink/Main.kt
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.OnlineStatus
 import net.dv8tion.jda.api.requests.GatewayIntent
 import net.luckperms.api.LuckPerms
+import net.luckperms.api.LuckPermsProvider
 import org.bukkit.Bukkit
 import org.bukkit.event.Listener
 import org.bukkit.plugin.java.JavaPlugin
@@ -31,7 +32,7 @@ class Main : JavaPlugin() {
 
         val provider = Bukkit.getServicesManager().getRegistration(LuckPerms::class.java)
         if (provider != null)
-            luckPerms = provider.provider
+            luckPerms = LuckPermsProvider.get()
 
         loadCommands()
         loadListeners()


### PR DESCRIPTION
・`Spigot API`を`1.17.1`へアップデート
・`JDA`を`4.3.0_346`へアップデート
・`LuckPerms`を`5.3`へアップデート
・`LuckPerms`が読み込めなかった際にエラーを出すように変更